### PR TITLE
Eliminate unnecessary function calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ let bv3 = @immut_BitVector.from_bools(bools)  // Results in "01010"
 let bv4 = @immut_BitVector.from_string("10110")  // From binary string
 
 // Create from integer array
-let ints = FixedArray::make(2, (0).to_uint64())
-ints[0] = (42).to_uint64()  // Binary: ...0101010
+let ints = FixedArray::make(2, 0UL)
+ints[0] = 42UL  // Binary: ...0101010
 let bv5 = @immut_BitVector.from_ints(ints, 128)  // 128-bit length vector
 ```
 

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -45,8 +45,8 @@ let bv3 = @immut_BitVector.from_bools(bools)  // 结果为"01010"
 let bv4 = @immut_BitVector.from_string("10110")  // 从二进制字符串创建
 
 // 从整数数组创建
-let ints = FixedArray::make(2, (0).to_uint64())
-ints[0] = (42).to_uint64()  // 二进制：...0101010
+let ints = FixedArray::make(2, 0UL)
+ints[0] = 42UL  // 二进制：...0101010
 let bv5 = @immut_BitVector.from_ints(ints, 128)  // 长度为128位的向量
 ```
 

--- a/src/immut_BitVector.mbt
+++ b/src/immut_BitVector.mbt
@@ -154,7 +154,7 @@ pub fn clear(self : BitVector, index : Int) -> BitVector {
 
   // Create a new bit vector
   let new_data = self.data.copy()
-  new_data[word_idx] = new_data[word_idx] & (UINT64_MAX ^ (1UL << bit_idx))
+  new_data[word_idx] = new_data[word_idx] & (1UL << bit_idx).lnot()
   { data: new_data, length: self.length, last_mask: self.last_mask }
 }
 
@@ -180,7 +180,7 @@ pub fn flip_all(self : BitVector) -> BitVector {
 
   // Flip all integers
   for i in 0..<new_data.length() {
-    new_data[i] = new_data[i] ^ UINT64_MAX
+    new_data[i] = new_data[i].lnot()
   }
 
   // Ensure invalid bits in the last integer are 0

--- a/src/immut_BitVector.mbt
+++ b/src/immut_BitVector.mbt
@@ -14,14 +14,14 @@ pub fn new(length : Int) -> BitVector {
 
   // Calculate how many UInt64s are needed to store bits of specified length
   let num_ints = (length + 63) >> 6
-  let data = FixedArray::make(num_ints, (0).to_uint64())
+  let data = FixedArray::make(num_ints, 0UL)
 
   // Calculate the valid bit mask for the last UInt64
   let remainder = length & 63 // equivalent to length % 64
   let last_mask = if remainder == 0 {
     UINT64_MAX
   } else {
-    ((1).to_uint64() << remainder) - (1).to_uint64()
+    (1UL << remainder) - 1UL
   }
   { data, length, last_mask }
 }
@@ -59,7 +59,7 @@ pub fn from_ints(ints : FixedArray[UInt64], length : Int) -> BitVector {
   let last_mask = if remainder == 0 {
     UINT64_MAX
   } else {
-    ((1).to_uint64() << remainder) - (1).to_uint64()
+    (1UL << remainder) - 1UL
   }
 
   // Copy array and clear invalid bits in the last UInt64
@@ -81,7 +81,7 @@ pub fn from_bools(bools : FixedArray[Bool]) -> BitVector {
     if bools[i] {
       let word_idx = i >> 6 // divide by 64
       let bit_idx = i & 63 // modulo 64
-      bv.data[word_idx] = bv.data[word_idx] | ((1).to_uint64() << bit_idx)
+      bv.data[word_idx] = bv.data[word_idx] | (1UL << bit_idx)
     }
   }
   bv
@@ -96,7 +96,7 @@ pub fn from_string(s : String) -> BitVector {
     if s[i] == '1' {
       let word_idx = i >> 6
       let bit_idx = i & 63
-      bv.data[word_idx] = bv.data[word_idx] | ((1).to_uint64() << bit_idx)
+      bv.data[word_idx] = bv.data[word_idx] | (1UL << bit_idx)
     } else if s[i] != '0' {
       abort("String must contain only '0' and '1' characters")
     }
@@ -115,7 +115,7 @@ pub fn get(self : BitVector, index : Int) -> Bool {
   }
   let word_idx = index >> 6
   let bit_idx = index & 63
-  (self.data[word_idx] & ((1).to_uint64() << bit_idx)) != 0
+  (self.data[word_idx] & (1UL << bit_idx)) != 0
 }
 
 ///|
@@ -128,13 +128,13 @@ pub fn set(self : BitVector, index : Int) -> BitVector {
   let bit_idx = index & 63
 
   // If the bit is already 1, return the original bit vector
-  if (self.data[word_idx] & ((1).to_uint64() << bit_idx)) != 0 {
+  if (self.data[word_idx] & (1UL << bit_idx)) != 0 {
     return self
   }
 
   // Create a new bit vector
   let new_data = self.data.copy()
-  new_data[word_idx] = new_data[word_idx] | ((1).to_uint64() << bit_idx)
+  new_data[word_idx] = new_data[word_idx] | (1UL << bit_idx)
   { data: new_data, length: self.length, last_mask: self.last_mask }
 }
 
@@ -148,14 +148,13 @@ pub fn clear(self : BitVector, index : Int) -> BitVector {
   let bit_idx = index & 63
 
   // If the bit is already 0, return the original bit vector
-  if (self.data[word_idx] & ((1).to_uint64() << bit_idx)) == 0 {
+  if (self.data[word_idx] & (1UL << bit_idx)) == 0 {
     return self
   }
 
   // Create a new bit vector
   let new_data = self.data.copy()
-  new_data[word_idx] = new_data[word_idx] &
-    (UINT64_MAX ^ ((1).to_uint64() << bit_idx))
+  new_data[word_idx] = new_data[word_idx] & (UINT64_MAX ^ (1UL << bit_idx))
   { data: new_data, length: self.length, last_mask: self.last_mask }
 }
 
@@ -170,7 +169,7 @@ pub fn flip(self : BitVector, index : Int) -> BitVector {
 
   // Create a new bit vector
   let new_data = self.data.copy()
-  new_data[word_idx] = new_data[word_idx] ^ ((1).to_uint64() << bit_idx)
+  new_data[word_idx] = new_data[word_idx] ^ (1UL << bit_idx)
   { data: new_data, length: self.length, last_mask: self.last_mask }
 }
 
@@ -202,7 +201,7 @@ pub fn and(self : BitVector, other : BitVector) -> BitVector {
   if self.length != other.length {
     abort("BitVectors must have the same length for logical operations")
   }
-  let new_data = FixedArray::make(self.data.length(), (0).to_uint64())
+  let new_data = FixedArray::make(self.data.length(), 0UL)
 
   // Perform bitwise AND operation
   for i in 0..<new_data.length() {
@@ -217,7 +216,7 @@ pub fn or(self : BitVector, other : BitVector) -> BitVector {
   if self.length != other.length {
     abort("BitVectors must have the same length for logical operations")
   }
-  let new_data = FixedArray::make(self.data.length(), (0).to_uint64())
+  let new_data = FixedArray::make(self.data.length(), 0UL)
 
   // Perform bitwise OR operation
   for i in 0..<new_data.length() {
@@ -232,7 +231,7 @@ pub fn xor(self : BitVector, other : BitVector) -> BitVector {
   if self.length != other.length {
     abort("BitVectors must have the same length for logical operations")
   }
-  let new_data = FixedArray::make(self.data.length(), (0).to_uint64())
+  let new_data = FixedArray::make(self.data.length(), 0UL)
 
   // Perform bitwise XOR operation
   for i in 0..<new_data.length() {
@@ -350,7 +349,7 @@ pub fn slice(self : BitVector, start : Int, end : Int) -> BitVector {
 
   // 处理切片在单个字内的情况
   if start_word == end_word {
-    let mask = (((1).to_uint64() << (end_bit - start_bit + 1)) - 1) << start_bit
+    let mask = ((1UL << (end_bit - start_bit + 1)) - 1) << start_bit
     let bits = (self.data[start_word] & mask) >> start_bit
     result.data[0] = bits
     return result
@@ -528,7 +527,7 @@ pub fn not(self : BitVector) -> BitVector {
 
 ///| Creates a bit mask at the specified position (that bit is 1, others are 0)
 pub fn bit_mask(bit_pos : Int) -> UInt64 {
-  (1).to_uint64() << bit_pos
+  1UL << bit_pos
 }
 
 ///| Creates a mask from 0 to the specified position (those bits are 1)
@@ -536,5 +535,5 @@ pub fn low_bits_mask(pos : Int) -> UInt64 {
   if pos >= 63 {
     return UINT64_MAX
   }
-  ((1).to_uint64() << (pos + 1)) - 1
+  (1UL << (pos + 1)) - 1
 }

--- a/src/immut_BitVector.mbt
+++ b/src/immut_BitVector.mbt
@@ -3,9 +3,7 @@
 /// It provides a series of bit operations while maintaining immutability (all modification operations return new BitVector instances).
 
 ///|
-pub fn uint64_max() -> UInt64 {
-  return (-1).to_uint64()
-}
+pub const UINT64_MAX = 0xffffffffffffffffUL
 
 ///|
 /// Creates a bit vector of specified length with all bits set to 0
@@ -21,7 +19,7 @@ pub fn new(length : Int) -> BitVector {
   // Calculate the valid bit mask for the last UInt64
   let remainder = length & 63 // equivalent to length % 64
   let last_mask = if remainder == 0 {
-    uint64_max()
+    UINT64_MAX
   } else {
     ((1).to_uint64() << remainder) - (1).to_uint64()
   }
@@ -35,12 +33,12 @@ pub fn ones(length : Int) -> BitVector {
 
   // Fill all UInt64s with 1s
   for i = 0; i < bv.data.length(); i = i + 1 {
-    bv.data[i] = uint64_max()
+    bv.data[i] = UINT64_MAX
   }
 
   // Set the last UInt64, only setting valid bits to 1
   if bv.data.length() > 0 {
-    bv.data[bv.data.length() - 1] = uint64_max() & bv.last_mask
+    bv.data[bv.data.length() - 1] = UINT64_MAX & bv.last_mask
   }
   bv
 }
@@ -59,7 +57,7 @@ pub fn from_ints(ints : FixedArray[UInt64], length : Int) -> BitVector {
   // Calculate the valid bit mask for the last UInt64
   let remainder = length & 63
   let last_mask = if remainder == 0 {
-    uint64_max()
+    UINT64_MAX
   } else {
     ((1).to_uint64() << remainder) - (1).to_uint64()
   }
@@ -157,7 +155,7 @@ pub fn clear(self : BitVector, index : Int) -> BitVector {
   // Create a new bit vector
   let new_data = self.data.copy()
   new_data[word_idx] = new_data[word_idx] &
-    (uint64_max() ^ ((1).to_uint64() << bit_idx))
+    (UINT64_MAX ^ ((1).to_uint64() << bit_idx))
   { data: new_data, length: self.length, last_mask: self.last_mask }
 }
 
@@ -183,7 +181,7 @@ pub fn flip_all(self : BitVector) -> BitVector {
 
   // Flip all integers
   for i in 0..<new_data.length() {
-    new_data[i] = new_data[i] ^ uint64_max()
+    new_data[i] = new_data[i] ^ UINT64_MAX
   }
 
   // Ensure invalid bits in the last integer are 0
@@ -299,7 +297,7 @@ pub fn find_first_set(self : BitVector) -> Int {
 ///|
 /// Finds the index of the first bit set to 0 in the integer, returns -1 if none
 pub fn lowest_unset_bit(x : UInt64) -> Int {
-  if x == uint64_max() {
+  if x == UINT64_MAX {
     return 64 // indicates no 0 bits
   }
   let mut pos = 0
@@ -504,7 +502,7 @@ pub fn is_all_zeros(self : BitVector) -> Bool {
 /// Checks if the bit vector is all ones
 pub fn is_all_ones(self : BitVector) -> Bool {
   for i = 0; i < self.data.length() - 1; i = i + 1 {
-    if self.data[i] != uint64_max() {
+    if self.data[i] != UINT64_MAX {
       return false
     }
   }
@@ -536,7 +534,7 @@ pub fn bit_mask(bit_pos : Int) -> UInt64 {
 ///| Creates a mask from 0 to the specified position (those bits are 1)
 pub fn low_bits_mask(pos : Int) -> UInt64 {
   if pos >= 63 {
-    return uint64_max()
+    return UINT64_MAX
   }
   ((1).to_uint64() << (pos + 1)) - 1
 }

--- a/src/immut_BitVector_test.mbt
+++ b/src/immut_BitVector_test.mbt
@@ -19,7 +19,7 @@ test "ones_constructor" {
 
 ///|
 test "from_ints_constructor" {
-  let ints = FixedArray::from_array([(3).to_uint64(), (7).to_uint64()]) // 二进制: 11 and 111
+  let ints = FixedArray::from_array([3UL, 7UL]) // 二进制: 11 and 111
   let bv = @immut_BitVector.from_ints(ints, 128)
   assert_eq!(bv.get(0), true)
   assert_eq!(bv.get(1), true)
@@ -232,20 +232,20 @@ test "not_operation" {
 test "bit_mask_function" {
   // 测试位掩码辅助函数
   let mask0 = @immut_BitVector.bit_mask(0)
-  assert_eq!(mask0, (1).to_uint64())
+  assert_eq!(mask0, 1UL)
   let mask5 = @immut_BitVector.bit_mask(5)
-  assert_eq!(mask5, (1 << 5).to_uint64())
+  assert_eq!(mask5, 1UL << 5)
   let mask63 = @immut_BitVector.bit_mask(63)
-  assert_eq!(mask63, (1).to_uint64() << 63)
+  assert_eq!(mask63, 1UL << 63)
 }
 
 ///|
 test "low_bits_mask_function" {
   // 测试低位掩码辅助函数
   let mask0 = @immut_BitVector.low_bits_mask(0)
-  assert_eq!(mask0, (1).to_uint64())
+  assert_eq!(mask0, 1UL)
   let mask3 = @immut_BitVector.low_bits_mask(3)
-  assert_eq!(mask3, (15).to_uint64()) // 1111 二进制
+  assert_eq!(mask3, 15UL) // 1111 二进制
   let mask63 = @immut_BitVector.low_bits_mask(63)
   assert_eq!(mask63, @immut_BitVector.UINT64_MAX)
 }
@@ -253,11 +253,11 @@ test "low_bits_mask_function" {
 ///|
 test "lowest_set_bit_function" {
   // 测试查找最低的1位
-  let num1 = (1).to_uint64() // 二进制: 0...01
+  let num1 = 1UL // 二进制: 0...01
   assert_eq!(@immut_BitVector.lowest_set_bit(num1), 0)
-  let num2 = (8).to_uint64() // 二进制: 0...01000
+  let num2 = 8UL // 二进制: 0...01000
   assert_eq!(@immut_BitVector.lowest_set_bit(num2), 3)
-  let num3 = (0).to_uint64() // 全0
+  let num3 = 0UL // 全0
   assert_eq!(@immut_BitVector.lowest_set_bit(num3), -1)
 }
 
@@ -500,12 +500,12 @@ test "serialization_roundtrip" {
 /// 测试lowest_unset_bit函数
 test "lowest_unset_bit_function" {
   // 测试正常情况，低位有一些0
-  assert_eq!(@immut_BitVector.lowest_unset_bit((10).to_uint64()), 0) // 1010二进制，最低位是0
-  assert_eq!(@immut_BitVector.lowest_unset_bit((6).to_uint64()), 0) // 0110二进制，最低位是0
+  assert_eq!(@immut_BitVector.lowest_unset_bit(10UL), 0) // 1010二进制，最低位是0
+  assert_eq!(@immut_BitVector.lowest_unset_bit(6UL), 0) // 0110二进制，最低位是0
 
   // 测试连续几个1后才有0的情况
-  assert_eq!(@immut_BitVector.lowest_unset_bit((7).to_uint64()), 3) // 0111二进制，第3位是第一个0
-  assert_eq!(@immut_BitVector.lowest_unset_bit((15).to_uint64()), 4) // 1111二进制，第4位是第一个0
+  assert_eq!(@immut_BitVector.lowest_unset_bit(7UL), 3) // 0111二进制，第3位是第一个0
+  assert_eq!(@immut_BitVector.lowest_unset_bit(15UL), 4) // 1111二进制，第4位是第一个0
 
   // 测试全为1的情况
   assert_eq!(@immut_BitVector.lowest_unset_bit(@immut_BitVector.UINT64_MAX), 64)

--- a/src/immut_BitVector_test.mbt
+++ b/src/immut_BitVector_test.mbt
@@ -247,7 +247,7 @@ test "low_bits_mask_function" {
   let mask3 = @immut_BitVector.low_bits_mask(3)
   assert_eq!(mask3, (15).to_uint64()) // 1111 二进制
   let mask63 = @immut_BitVector.low_bits_mask(63)
-  assert_eq!(mask63, @immut_BitVector.uint64_max())
+  assert_eq!(mask63, @immut_BitVector.UINT64_MAX)
 }
 
 ///|
@@ -508,10 +508,7 @@ test "lowest_unset_bit_function" {
   assert_eq!(@immut_BitVector.lowest_unset_bit((15).to_uint64()), 4) // 1111二进制，第4位是第一个0
 
   // 测试全为1的情况
-  assert_eq!(
-    @immut_BitVector.lowest_unset_bit(@immut_BitVector.uint64_max()),
-    64,
-  )
+  assert_eq!(@immut_BitVector.lowest_unset_bit(@immut_BitVector.UINT64_MAX), 64)
 }
 
 ///|
@@ -592,9 +589,10 @@ test "from_ints_with_remainder" {
   // 创建一个长度不是64倍数的UInt64数组
   // 例如，创建一个长度为100位的位向量(需要2个UInt64)
   let ints = FixedArray::from_array([
-    uint64_max(), // 第一个UInt64全为1
-    uint64_max(), // 第二个UInt64全为1，但我们只需要使用前36位
-  ])
+      UINT64_MAX, // 第一个UInt64全为1
+      UINT64_MAX,
+    ], // 第二个UInt64全为1，但我们只需要使用前36位
+  )
 
   // 创建长度为100的位向量
   let bv = @immut_BitVector.from_ints(ints, 100)
@@ -611,8 +609,6 @@ test "from_ints_with_remainder" {
   for i in 64..<100 {
     assert_true!(bv.get(i))
   }
-
-
 }
 
 ///|

--- a/src/panic_test.mbt
+++ b/src/panic_test.mbt
@@ -55,7 +55,7 @@ test "panic slice with start greater than end should panic" {
 
 ///|
 test "panic from_ints with mismatched length should panic" {
-  let ints = FixedArray::from_array([(3).to_uint64(), (7).to_uint64()])
+  let ints = FixedArray::from_array([3UL, 7UL])
   let result = @immut_BitVector.from_ints(ints, 300) // 位数不能匹配整数数组长度
   result |> ignore
 } //
@@ -100,14 +100,14 @@ test "panic concat resulting in excessive length should panic" {
 
 ///|
 test "panic from_ints with non-positive length should panic" {
-  let ints = FixedArray::from_array([(3).to_uint64(), (7).to_uint64()])
+  let ints = FixedArray::from_array([3UL, 7UL])
   let result = @immut_BitVector.from_ints(ints, -1) // 使用负数长度
   result |> ignore
 }
 
 ///|
 test "panic from_ints with zero length should panic" {
-  let ints = FixedArray::from_array([(3).to_uint64(), (7).to_uint64()])
+  let ints = FixedArray::from_array([3UL, 7UL])
   let result = @immut_BitVector.from_ints(ints, 0) // 使用零长度
   result |> ignore
 }


### PR DESCRIPTION
This PR optimizes the code by replacing three patterns that incur unnecessary runtime overhead:  

1. Replaced `uint64_max()` function with a constant (`UINT64_MAX`)  
2. Changed `(c).to_uint64()` to literal suffix syntax (`cUL`)
3. Changed `x ^ UINT64_MAX` to `x.lnot()`, which directly compiles to WASM's `u64.bitnot` instruction